### PR TITLE
HBSD: Properly document how to build 32bit libs.

### DIFF
--- a/emulators/virtualbox-ose/Makefile
+++ b/emulators/virtualbox-ose/Makefile
@@ -251,7 +251,7 @@ pre-everything::
 	@${FALSE}
 .elif !exists(/usr/lib32/libc.so)
 	@${ECHO} 'Requires 32-bit libraries installed under /usr/lib32.'
-	@${ECHO} 'Do: cd /usr/src; make build32 install32; service ldconfig restart'
+	@${ECHO} 'Do: cd /usr/src; WITH_LIB32=yes make build32 install32; service ldconfig restart'
 	@${FALSE}
 .endif
 .endif


### PR DESCRIPTION
As lib32 is opt-in on HardenedBSD, update jkim's build instructions to take
into account that WITH_LIB32 needs to be set to `yes` prior to running make
build32.