### PR TITLE
Change SSP_CFLAGS to -fstack-protector-all

### DIFF
--- a/Mk/bsd.ssp.mk
+++ b/Mk/bsd.ssp.mk
@@ -5,8 +5,8 @@ SSP_Include_MAINTAINER=	portmgr@FreeBSD.org
 
 .if !defined(SSP_UNSAFE) && \
     (${ARCH} == i386 || ${ARCH} == amd64)
-# Overridable as a user may want to use -fstack-protector-all
-SSP_CFLAGS?=	-fstack-protector
+# Overridable as a user may want to use -fstack-protector
+SSP_CFLAGS?=	-fstack-protector-all
 CFLAGS+=	${SSP_CFLAGS}
 LDFLAGS+=	-fstack-protector
 # -lssp_nonshared is needed on i386 where /usr/lib/libc.so is not an ldscript


### PR DESCRIPTION
This change makes ports use the full Stack Protector setting.

I've been building ports with this setting on 11-STABLE for about half a year now, it hasn't caused me any issues.