### PR TITLE
Enable SafeStack

### DIFF
--- a/print/hplip/Makefile
+++ b/print/hplip/Makefile
@@ -9,6 +9,8 @@ MASTER_SITES=	SF
 MAINTAINER=	woodsb02@FreeBSD.org
 COMMENT=	Drivers and utilities for HP printers and All-in-One devices
 
+USE_HARDENING=	safestack
+
 LICENSE=	GPLv2 MIT BSD3CLAUSE
 LICENSE_COMB=	multi
 LICENSE_FILE=	${WRKSRC}/COPYING


### PR DESCRIPTION
If you enable SNMP, this port won't compile with SafeStack disabled.