### PR TITLE
HBSD: hardenedbsd/secadm: fix build

### DIFF
--- a/hardenedbsd/secadm/Makefile
+++ b/hardenedbsd/secadm/Makefile
@@ -20,6 +20,7 @@ GH_PROJECT=	secadm
 
 .if !defined(KMOD)
 LIBDIR?=	${PREFIX}/lib
+MAKE_ENV+=	LIBDIR=${LIBDIR}
 .endif
 
 MAKE_JOBS_UNSAFE=	yes


### PR DESCRIPTION
Previously, LIBDIR was implicitly passed to MAKE_ENV.
This was changed in r469953 upstream.

Pass it explicitly, so that libsecadm can install to STAGEDIR again.

Signed-off-by:	Johannes Meixner <johannes@perceivon.net>