### PR TITLE
www/node: Use binutils from ports with BUNDLED_SSL

### DIFF
--- a/www/node/Makefile
+++ b/www/node/Makefile
@@ -36,6 +36,11 @@ BUNDLED_SSL_DESC=		Use node.js's bundled OpenSSL implementation
 BUNDLED_SSL_USES_OFF=		ssl
 BUNDLED_SSL_CONFIGURE_OFF=	--shared-openssl --openssl-use-def-ca-store
 BUNDLED_SSL_RUN_DEPENDS_OFF=	ca_root_nss>=0:security/ca_root_nss
+BUNDLED_SSL_USE=		binutils=yes
+BUNDLED_SSL_EXTRA_PATCHES=	${PATCHDIR}/extra-patch-deps_v8_tools_disasm.py \
+				${PATCHDIR}/extra-patch-deps_v8_tools_grokdump.py \
+				${PATCHDIR}/extra-patch-deps_v8_tools_ll__prof.py \
+				files/extra-patch_tools_genv8constants.py
 
 NLS_CONFIGURE_ON=	--with-intl=system-icu
 NLS_LIB_DEPENDS=	libicui18n.so:devel/icu

--- a/www/node/files/extra-patch-deps_v8_tools_disasm.py
+++ b/www/node/files/extra-patch-deps_v8_tools_disasm.py
@@ -1,0 +1,11 @@
+--- deps/v8/tools/disasm.py.orig	2018-06-10 08:55:38 UTC
++++ deps/v8/tools/disasm.py
+@@ -34,7 +34,7 @@ import tempfile
+ 
+ 
+ # Avoid using the slow (google-specific) wrapper around objdump.
+-OBJDUMP_BIN = "/usr/bin/objdump"
++OBJDUMP_BIN = "/usr/local/bin/objdump"
+ if not os.path.exists(OBJDUMP_BIN):
+   OBJDUMP_BIN = "objdump"
+ 

--- a/www/node/files/extra-patch-deps_v8_tools_grokdump.py
+++ b/www/node/files/extra-patch-deps_v8_tools_grokdump.py
@@ -1,0 +1,11 @@
+--- deps/v8/tools/grokdump.py.orig	2018-06-10 08:55:46 UTC
++++ deps/v8/tools/grokdump.py
+@@ -584,7 +584,7 @@ MD_CPU_ARCHITECTURE_ARM64 = 0x8003
+ MD_CPU_ARCHITECTURE_AMD64 = 9
+ 
+ OBJDUMP_BIN = None
+-DEFAULT_OBJDUMP_BIN = '/usr/bin/objdump'
++DEFAULT_OBJDUMP_BIN = '/usr/local/bin/objdump'
+ 
+ class FuncSymbol:
+   def __init__(self, start, size, name):

--- a/www/node/files/extra-patch-deps_v8_tools_ll__prof.py
+++ b/www/node/files/extra-patch-deps_v8_tools_ll__prof.py
@@ -1,0 +1,11 @@
+--- deps/v8/tools/ll_prof.py.orig	2018-06-10 08:55:52 UTC
++++ deps/v8/tools/ll_prof.py
+@@ -869,7 +869,7 @@ if __name__ == "__main__":
+                     default="/tmp/__v8_gc__",
+                     help="gc fake mmap file [default: %default]")
+   parser.add_option("--objdump",
+-                    default="/usr/bin/objdump",
++                    default="/usr/local/bin/objdump",
+                     help="objdump tool to use [default: %default]")
+   parser.add_option("--host-root",
+                     default="",

--- a/www/node/files/extra-patch_tools_genv8constants.py
+++ b/www/node/files/extra-patch_tools_genv8constants.py
@@ -1,0 +1,11 @@
+--- tools/genv8constants.py.orig	2018-06-10 09:22:07.876673000 +0000
++++ tools/genv8constants.py	2018-06-10 09:22:18.437062000 +0000
+@@ -18,7 +18,7 @@
+ 
+ outfile = file(sys.argv[1], 'w');
+ try:
+-  pipe = subprocess.Popen([ 'objdump', '-z', '-D', sys.argv[2] ],
++  pipe = subprocess.Popen([ '/usr/local/bin/objdump', '-z', '-D', sys.argv[2] ],
+       bufsize=-1, stdout=subprocess.PIPE).stdout;
+ except OSError, e:
+   if e.errno == errno.ENOENT:


### PR DESCRIPTION
www/node does not work well with with BUNDLED_SSL
when DTRACE is on (default) and we are using an older
binutils version. FreeBSD is using the last GPLv2 one,
which does not provide options expected by a few python
scripts.

Use ports binutils and patch python scripts to use it.

Signed-off-by:	Johannes Meixner <johannes@perceivon.net>