### PR TITLE
Disable PIO on devel/stlink

### DIFF
--- a/devel/stlink/Makefile
+++ b/devel/stlink/Makefile
@@ -18,6 +18,8 @@ GTK3_USE=		GNOME=gtk30
 USE_GITHUB=	yes
 GH_ACCOUNT=	texane
 
+USE_HARDENING=	pie:off
+
 USES=		cmake pkgconfig
 USE_LDCONFIG=	yes
 


### PR DESCRIPTION
I successfully flash my STM32 devices with this package, but it doesn't build with PIE. Tested with Nucleo-F401RE.