### PR TITLE
New Port: OpenNMS Minion

### DIFF
--- a/net/opennms-minion/Makefile
+++ b/net/opennms-minion/Makefile
@@ -1,0 +1,65 @@
+# $FreeBSD$
+
+PORTNAME=	opennms-minion
+PORTVERSION=	${OPENNMS_MAJOR_VERSION}.${OPENNMS_MINOR_VERSION}.${OPENNMS_INC_VERSION}.${OPENNMS_DATE_VERSION}
+PORTREVISION=	0
+CATEGORIES=	net java
+
+MASTER_SITES=	http://yum.opennms.org/stable/common/opennms/:source1 \
+                http://central.maven.org/maven2/:source2
+DISTFILES+=	opennms-minion-container-${OPENNMS_PACKAGE_VERSION}.noarch.rpm:source1 \
+		opennms-minion-features-core-${OPENNMS_PACKAGE_VERSION}.noarch.rpm:source1 \
+		opennms-minion-features-default-${OPENNMS_PACKAGE_VERSION}.noarch.rpm:source1 \
+                net/java/dev/jna/jna/4.5.1/jna-4.5.1.jar:source2 \
+                net/java/dev/jna/jna-platform/4.5.1/jna-platform-4.5.1.jar:source2
+EXTRACT_ONLY=	opennms-minion-container-${OPENNMS_PACKAGE_VERSION}.noarch.rpm \
+                opennms-minion-features-core-${OPENNMS_PACKAGE_VERSION}.noarch.rpm \
+                opennms-minion-features-default-${OPENNMS_PACKAGE_VERSION}.noarch.rpm
+
+MAINTAINER=	jesse@opennms.org
+COMMENT?=	OpenNMS Minion ${OPENNMS_MAJOR_VERSION}
+
+LICENSE=	AGPLv3
+
+EXTRACT_DEPENDS=	rpm2cpio.pl:${PORTSDIR}/archivers/rpm2cpio
+RUN_DEPENDS=	javavm:${PORTSDIR}/java/javavmwrapper
+
+OPENNMS_MAJOR_VERSION=  24
+OPENNMS_MINOR_VERSION=  0
+OPENNMS_INC_VERSION=    0
+OPENNMS_DATE_VERSION=	2019.04.26
+
+OPENNMS_PACKAGE_VERSION=	24.0.0-1
+
+USES=           perl5
+USE_JAVA=       yes
+JAVA_OS=        native
+JAVA_VERSION=   1.8
+JAVA_VENDOR=    openjdk
+JAVA_RUN=       yes
+
+RUN_DEPENDS+=   bash:${PORTSDIR}/shells/bash
+
+USERS=		minion
+GROUPS=		minion
+
+MINIONOWN=      minion
+MINIONGRP=      minion
+
+INSTPREFIX= 	${PREFIX}/minion
+
+NO_BUILD=	yes
+
+do-install:
+		${MKDIR} ${STAGEDIR}${INSTPREFIX}
+		(cd ${WRKDIR}/opt/minion && ${COPYTREE_SHARE} . ${STAGEDIR}${INSTPREFIX})
+		(cd ${WRKDIR}/opt/minion/bin && ${COPYTREE_BIN} . ${STAGEDIR}${INSTPREFIX}/bin)
+		(cp ${DISTDIR}/net/java/dev/jna/jna/4.5.1/jna-4.5.1.jar ${STAGEDIR}${INSTPREFIX}/lib/boot/jna-4.4.0.jar)
+		(cp ${DISTDIR}/net/java/dev/jna/jna/4.5.1/jna-4.5.1.jar ${STAGEDIR}${INSTPREFIX}/repositories/default/net/java/dev/jna/jna/4.4.0/jna-4.4.0.jar)
+		(cp ${DISTDIR}/net/java/dev/jna/jna/4.5.1/jna-4.5.1.jar ${STAGEDIR}${INSTPREFIX}/system/net/java/dev/jna/jna/4.4.0/jna-4.4.0.jar)
+		(cp ${DISTDIR}/net/java/dev/jna/jna-platform/4.5.1/jna-platform-4.5.1.jar ${STAGEDIR}${INSTPREFIX}/lib/boot/jna-platform-4.4.0.jar)
+		(cp ${DISTDIR}/net/java/dev/jna/jna-platform/4.5.1/jna-platform-4.5.1.jar ${STAGEDIR}${INSTPREFIX}/repositories/default/net/java/dev/jna/jna-platform/4.4.0/jna-platform-4.4.0.jar)
+		(cp ${DISTDIR}/net/java/dev/jna/jna-platform/4.5.1/jna-platform-4.5.1.jar ${STAGEDIR}${INSTPREFIX}/system/net/java/dev/jna/jna-platform/4.4.0/jna-platform-4.4.0.jar)
+		@(cd ${STAGEDIR}${PREFIX}; ${FIND} -s minion -not -type d) >> ${TMPPLIST}
+
+.include <bsd.port.mk>

--- a/net/opennms-minion/distinfo
+++ b/net/opennms-minion/distinfo
@@ -1,0 +1,11 @@
+TIMESTAMP = 1556298487
+SHA256 (opennms-minion-container-24.0.0-1.noarch.rpm) = 50631a694d55ea48b2e10a285bd0b24934ffae86abcf40b2f08e64b2dbd1904c
+SIZE (opennms-minion-container-24.0.0-1.noarch.rpm) = 83528154
+SHA256 (opennms-minion-features-core-24.0.0-1.noarch.rpm) = 4e898916efb4899445466efab6ee7dc624694d17c3b2e41fbe37044393bf8141
+SIZE (opennms-minion-features-core-24.0.0-1.noarch.rpm) = 29409028
+SHA256 (opennms-minion-features-default-24.0.0-1.noarch.rpm) = 8f307bc43848b5853f72a28ee5afd2e743ebf2470a199b38ea4672bec0bd1cae
+SIZE (opennms-minion-features-default-24.0.0-1.noarch.rpm) = 148690825
+SHA256 (net/java/dev/jna/jna/4.5.1/jna-4.5.1.jar) = fbc9de96a0cc193a125b4008dbc348e9ed54e5e13fc67b8ed40e645d303cc51b
+SIZE (net/java/dev/jna/jna/4.5.1/jna-4.5.1.jar) = 1440662
+SHA256 (net/java/dev/jna/jna-platform/4.5.1/jna-platform-4.5.1.jar) = 84c8667555ee8dd91fef44b451419f6f16f71f727d5fc475a10c2663eba83abb
+SIZE (net/java/dev/jna/jna-platform/4.5.1/jna-platform-4.5.1.jar) = 2327547

--- a/net/opennms-minion/pkg-descr
+++ b/net/opennms-minion/pkg-descr
@@ -1,0 +1,3 @@
+OpenNMS Minion
+
+WWW: http://www.opennms.org

--- a/net/opennms-minion/pkg-descr
+++ b/net/opennms-minion/pkg-descr
@@ -1,3 +1,10 @@
-OpenNMS Minion
+OpenNMS Minion allows an OpenNMS deployment to run in a distributed manner.    
+
+OpenNMS Minion is an instance of the Karaf OSGi service that can run
+distributed OpenNMS components that are packaged as Karaf features. Minion
+devices are configured with a minimum amount of information necessary to
+connect to the OpenNMS machine and identify themselves to it. The operation of
+each Minion is controlled from the Dominion service running on a central
+OpenNMS installation.
 
 WWW: http://www.opennms.org


### PR DESCRIPTION
This is taken from the FreeBSD Ports maintained by @j-white here: https://github.com/j-white/FreeBSD-ports

Although that ports tree is a fork specifically for pfSense, I believe this should work OK for HardenedBSD.